### PR TITLE
friendlier error message and ability to silence the saveSong entirely

### DIFF
--- a/plugins/dbhistory/saveSong.js
+++ b/plugins/dbhistory/saveSong.js
@@ -4,7 +4,8 @@ var saveSong = {
     description: 'Send to the php database when a song changes.',
     config: {
         url: null,
-        key: null
+        key: null,
+        verboseErrors: false
     },
     onSongChange: function(request) {
         var http = require('http');
@@ -39,7 +40,13 @@ var saveSong = {
             var req = http.request(options, function(resp) {
                 console.log('saveSong response code: '+resp.statusCode);
                 resp.on('data', function(chunk) {
-                    request.sendChat(chunk);
+                    if (resp.statusCode == 403 && saveSong.config.verboseErrors) {
+                        request.sendChat('The song vote history was not saved to the database. It looks as though your api key needs to be updated in your GSBOT config.')
+                    }
+                    else if (saveSong.config.verboseErrors) {
+                        request.sendChat('There was an error code '+resp.statusCode+' encountered while saving the song vote history.')
+                        console.log('BODY: ' + chunk);
+                    }
                     console.log('HEADERS: '+JSON.stringify(resp.headers));
                 })
 


### PR DESCRIPTION
Now people can decide to have saveSong enabled, and if any problems are encountered, they dont have to tell the world of the problem. sendChat is only called if verboseErrors is true.

Also: will resolve issue #41 