### PR TITLE
Wrapped Module Callbacks to cause them to be called with a proper this context

### DIFF
--- a/core/moduleloader.js
+++ b/core/moduleloader.js
@@ -50,7 +50,10 @@ var moduleLoader = {
     Object.keys(moduleLoader.callback).forEach(function(cbName) {
         if (typeof module[cbName] == 'function')
         {
-            moduleLoader.callback[cbName].push(module[cbName]);
+            // Wrap all the callbacks so that they can be executed with
+            // the correct this context.
+            var cb = function() { return module[cbName].apply(module, arguments); };
+            moduleLoader.callback[cbName].push(cb);
             init = true;
         }
     });


### PR DESCRIPTION
**Problem**

Calls on plugins like `onCall`, `onSongChange` were not getting the correct value for `this` which was creating a requirement to call everything globally `myPlugin.otherFunc()` where other functions like `init` would have the correct `this` value. This situation called for very inconsistent calling in plugins.

**Solution**

By wrapping the callbacks and executing them with `.apply` we can define the context they should execute as. Normal calls like `myInstance.onCall()` would do this automatically as per javascript's design, but when the functions were being stored in variables outside of the _dot operation_ context they cannot automatically infer their context we need to provide it explicitly.

**Notes**

This should not affect any exiting plugins as the `this` variable would have been incorrect and wouldn't have been used for anything, all this does is adds functionality to the plugin system.

Also: [See this eloquent tweet](https://twitter.com/bhalp1/status/578925947245633536)
